### PR TITLE
Removes mentioning of fundraiser plugin integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,21 +462,6 @@ If set, the plugin will save the specified number of donations as a custom post 
 
 ```
 
-## Integration with fundraising plugin
-To reference the post ID of a [fundraiser](https://github.com/ea-foundation/matching-campaigns), set the fundraiser option. The fundraiser ID can be found in the URL, e.g. `https://example.org/wp-admin/post.php?post=<fundraiser_id>&action=edit`.
-
-```json
-{
-  "forms": {
-    "my_form": {
-      "payment": {
-        "fundraiser": 159
-      },
-    }
-  }
-}
-```
-
 ## Tests
 Requires `phpunit`.
 


### PR DESCRIPTION
The link goes to nowhere. I assume the plugin does not exist anymore.