### PR TITLE
Fix broken country lookup by replacing geoip.net by ipstack.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,9 @@ Initially, the default settings are loaded from `_parameters.js.php.dist`. Once 
           "comment": false # add comment textarea
         },
         "country": {
-          "initial": "geoip",  # Initial value for country dropdown, e.g. "US"
-          "fallback": "US"  # Fallback value if GeoIP is not available
+          "initial": "ipstack",  # Initial value for country dropdown, e.g. "US". Default is "ipstack"
+          "ipstack_access_key": "abc1234", # Necessary if initial is "ipstack". See ipstack.com
+          "ipstack_fallback": "US" # Fallback country if ipstack API is not available
         },
         "recaptcha": {
           "site_key": "my_recaptcha_site_key",

--- a/raise.php
+++ b/raise.php
@@ -18,13 +18,13 @@ define('RAISE_PRIORITY', 12838790321);
 define('RAISE_ASSET_VERSION', '0.46');
 
 // Load other files
-require "vendor/autoload.php";
-require "_globals.php";
-require "_options.php";
-require "bitpay/EncryptedWPOptionStorage.php";
-require "functions.php";
-require "updates.php";
-require "form.php";
+require_once "vendor/autoload.php";
+require_once "_globals.php";
+require_once "_options.php";
+require_once "bitpay/EncryptedWPOptionStorage.php";
+require_once "functions.php";
+require_once "updates.php";
+require_once "form.php";
 
 // Add shortcode for donation form
 add_shortcode('raise_form','raise_form');


### PR DESCRIPTION
If you want the old geoip feature, add `payment > country > ipstack_access_key` (get it from ipstack.com) and remove `payment > country > initial`.

`payment > country > fallback` is now deprecated (but still supported). Use `payment > country > ipstack_fallback`.